### PR TITLE
Add packed data variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,19 @@ Computes vertex normals from for a mesh.
 
 **Returns** An array of normals
 
+## Packed data
+
+If your data is stored in packed, flattened arrays of cells and positions, you may instead require the packed-data variant:
+
+#### `require('angle-normals/packed')([normals, ] cells, positions)`
+
+Computes vertex normals for flattened arrays of cells and positions.
+
+* `normals` optional output array. Length matches that of `positions`.
+* `cells` a flat array of cells
+* `positions` a flat array of the mesh's vertices
+
+**Returns** A flat array of normals
+
 # License
 (c) 2015 Mikola Lysenko. MIT License

--- a/demo-packed.js
+++ b/demo-packed.js
@@ -1,0 +1,14 @@
+'use strict'
+
+var bunny = require('bunny')
+
+// Convert to packed data:
+var pack = require('array-pack-2d')
+bunny.cells = pack(bunny.cells, Uint16Array)
+bunny.positions = pack(bunny.positions)
+
+var normals = require('./packed')
+
+console.log('normals[0...9]:\n', normals(bunny.cells, bunny.positions).slice(0, 9))
+
+console.log('\nin-place variant: normals[0...9]:\n', normals([], bunny.cells, bunny.positions).slice(0, 9))

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "1.0.0",
   "description": "Compute mesh normals using angle weights",
   "main": "angle-normals.js",
-  "dependencies": {
-  },
   "devDependencies": {
+    "array-pack-2d": "^1.0.0",
     "bunny": "^1.0.1",
     "mesh-viewer": "^1.0.0",
     "simplicial-complex": "^1.0.0"

--- a/packed.js
+++ b/packed.js
@@ -1,0 +1,98 @@
+'use strict'
+
+module.exports = angleNormals
+
+function weight(s, r, a) {
+  return Math.atan2(r, (s - a))
+}
+
+function angleNormals(normals, cells, positions) {
+  var posDataLength, cellDataLength;
+
+  if (!positions) {
+    positions = cells
+    cells = normals
+    posDataLength = positions.length
+    cellDataLength = cells.length
+    normals = new Array(posDataLength)
+  } else {
+    posDataLength = positions.length
+    cellDataLength = cells.length
+  }
+
+  for(var i=0; i<posDataLength; i++) {
+    normals[i] = 0;
+  }
+
+  for(var cellPtr=0; cellPtr<cellDataLength; cellPtr += 3) {
+    var aIdx = cells[cellPtr] * 3;
+    var bIdx = cells[cellPtr + 1] * 3;
+    var cIdx = cells[cellPtr + 2] * 3;
+
+    var abx = positions[bIdx] - positions[aIdx]
+    var aby = positions[bIdx + 1] - positions[aIdx + 1]
+    var abz = positions[bIdx + 2] - positions[aIdx + 2]
+    var ab = Math.sqrt(abx * abx + aby * aby + abz * abz);
+
+    var bcx = positions[bIdx] - positions[cIdx]
+    var bcy = positions[bIdx + 1] - positions[cIdx + 1]
+    var bcz = positions[bIdx + 2] - positions[cIdx + 2]
+    var bc = Math.sqrt(bcx * bcx + bcy * bcy + bcz * bcz);
+
+    var cax = positions[cIdx] - positions[aIdx]
+    var cay = positions[cIdx + 1] - positions[aIdx + 1]
+    var caz = positions[cIdx + 2] - positions[aIdx + 2]
+    var ca = Math.sqrt(cax * cax + cay * cay + caz * caz);
+
+    if(Math.min(ab, bc, ca) < 1e-6) {
+      continue
+    }
+
+    var s = 0.5 * (ab + bc + ca)
+    var r = Math.sqrt((s - ab)*(s - bc)*(s - ca)/s)
+
+    var nx = aby * bcz - abz * bcy
+    var ny = abz * bcx - abx * bcz
+    var nz = abx * bcy - aby * bcx
+    var nl = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    nx /= nl
+    ny /= nl
+    nz /= nl
+
+    var w = Math.atan2(r, s - bc);
+    normals[aIdx] += w * nx;
+    normals[aIdx + 1] += w * ny;
+    normals[aIdx + 2] += w * nz;
+
+    w = Math.atan2(r, s - ca);
+    normals[bIdx] += w * nx;
+    normals[bIdx + 1] += w * ny;
+    normals[bIdx + 2] += w * nz;
+
+    w = Math.atan2(r, s - ab);
+    normals[cIdx] += w * nx;
+    normals[cIdx + 1] += w * ny;
+    normals[cIdx + 2] += w * nz;
+  }
+
+  //Normalize all the normals
+  for(var posPtr=0; posPtr<posDataLength; posPtr+=3) {
+    var l = Math.sqrt(
+      normals[posPtr] * normals[posPtr] +
+      normals[posPtr + 1] * normals[posPtr + 1] +
+      normals[posPtr + 2] * normals[posPtr + 2]
+    );
+
+    if(l < 1e-8) {
+      normals[posPtr] = 1
+      normals[posPtr + 1] = 0
+      normals[posPtr + 2] = 0
+      continue
+    }
+    normals[posPtr] /= l
+    normals[posPtr + 1] /= l
+    normals[posPtr + 2] /= l
+  }
+
+  return normals
+}


### PR DESCRIPTION
Lately I've been dealing in packed arrays of cells and vertices. This PR adds a `require('angle-normals/packed')` variant that expects flat arrays of cells and vertices, along with an optional output array for in-place storage.

Hate to cause feature-creep so am glad to publish under `angle-normals-packed` or take some other approach if you prefer to keep this repo streamlined.